### PR TITLE
Fix field validator error message for select list

### DIFF
--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -174,7 +174,7 @@ class SitesField extends Field implements PreviewableFieldInterface
 	 */
 	public function normalizeValue ($value, ElementInterface $element = null)
 	{
-		return (is_array($value)) ? $value : json_decode($value);
+		return (is_array($value)) ? $value : (string) json_decode($value);
 	}
 
 }


### PR DESCRIPTION
When Allow Multiple is not checked this field always produces a validation error: "Site must be a string."

Changing the content type of the field to integer when allow multiple is false caused DB exceptions when changing the allow multiple option on an existing field definition, so I chose this method for the fix which allows the content type to stay the same either way.