### PR TITLE
Enforce that the configuration for this field has at least one site

### DIFF
--- a/src/templates/_settings.html
+++ b/src/templates/_settings.html
@@ -6,6 +6,7 @@
 	id : 'whitelistedSites',
 	name : 'whitelistedSites',
 	values: field.whitelistedSites,
+    errors: field.getErrors('whitelistedSites'),
 	options : sites
 }) }}
 


### PR DESCRIPTION
Fixes #1 

- [x] Display an error message in forms where this field is used if the configuration does not have at least one site whitelisted.
- [x] Enable configuration validation that requires at least one site to be whitelisted in order to save the field settings.