### PR TITLE
add editorconfig.org file and update code files to match settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+max_line_length = 100
+tab_width = 4

--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -49,18 +49,18 @@ class SitesField extends Field implements PreviewableFieldInterface
 		return true;
 	}
 
-    /**
-     * @inheritdoc
-     */
-    public function __construct($config = [])
-    {
-        if (!array_key_exists('whitelistedSites', $config)
-            || ($config['whitelistedSites'] != '*' && !is_array($config['whitelistedSites']))) {
-            $config['whitelistedSites'] = [];
-        }
+	/**
+	 * @inheritdoc
+	 */
+	public function __construct($config = [])
+	{
+		if (!array_key_exists('whitelistedSites', $config)
+			|| ($config['whitelistedSites'] != '*' && !is_array($config['whitelistedSites']))) {
+			$config['whitelistedSites'] = [];
+		}
 
-        parent::__construct($config);
-    }
+		parent::__construct($config);
+	}
 
 	/**
 	 * @inheritdoc
@@ -93,7 +93,7 @@ class SitesField extends Field implements PreviewableFieldInterface
 	public function defineRules(): array
 	{
 		$rules = parent::rules();
-		
+
 		$rules[] = [['whitelistedSites'], 'validateSitesWhitelist', 'skipOnEmpty' => false];
 
 		return $rules;
@@ -104,15 +104,16 @@ class SitesField extends Field implements PreviewableFieldInterface
 	 * @param string $attribute The name of the attribute being validated.
 	 * @return void
 	 */
-	public function validateSitesWhitelist(string $attribute) {
-        if($this->whitelistedSites == '*') {
-            return;
-        }
+	public function validateSitesWhitelist(string $attribute)
+	{
+		if ($this->whitelistedSites == '*') {
+			return;
+		}
 
-        $av = new ArrayValidator(['min' => 1, 'skipOnEmpty' => false]);
-        if (!$av->validate($this->whitelistedSites, $error)) {
-            $this->addError($attribute, Craft::t('sites-field', $error));
-        }
+		$av = new ArrayValidator(['min' => 1, 'skipOnEmpty' => false]);
+		if (!$av->validate($this->whitelistedSites, $error)) {
+			$this->addError($attribute, Craft::t('sites-field', $error));
+		}
 
 		$sites = $this->getSites();
 
@@ -122,31 +123,31 @@ class SitesField extends Field implements PreviewableFieldInterface
 			}
 		}
 	}
-	
+
 	/**
 	 * @inheritdoc
+	 * @throws InvalidConfigException
 	 * @see craft\base\Field
-     * @throws InvalidConfigException
 	 */
 	public function getInputHtml($value, ElementInterface $element = null): string
 	{
-        if (empty($this->whitelistedSites)) {
-            throw new InvalidConfigException('At least one whitelisted site is required.');
-        }
+		if (empty($this->whitelistedSites)) {
+			throw new InvalidConfigException('At least one whitelisted site is required.');
+		}
 
 		$sites = $this->getSites(); // Get all sites available to the current user.
-        if($this->whitelistedSites == '*') {
-            $whitelist = array_keys($sites);
-        } else {
-            $whitelist = $this->whitelistedSites; // Get all whitelisted sites.
-        }
-        $whitelist[''] = ''; // Add a blank entry in, in case the field's options allow a 'None' selection.
-        $whitelist = array_flip($whitelist);
+		if ($this->whitelistedSites == '*') {
+			$whitelist = array_keys($sites);
+		} else {
+			$whitelist = $this->whitelistedSites; // Get all whitelisted sites.
+		}
+		$whitelist[''] = ''; // Add a blank entry in, in case the field's options allow a 'None' selection.
+		$whitelist = array_flip($whitelist);
 		if (!$this->allowMultiple && !$this->required) { // Add a 'None' option specifically for optional, single value fields.
 			$sites = ['' => Craft::t('app', 'None')] + $sites;
 		}
 		$whitelist = array_intersect_key($sites, $whitelist); // Discard any sites not available within the whitelist.
-		
+
 		return Craft::$app->getView()->renderTemplate(
 			'sites-field/_input', [
 				'field' => $this,
@@ -177,37 +178,38 @@ class SitesField extends Field implements PreviewableFieldInterface
 		$value = $element->getFieldValue($this->handle);
 		$sites = $this->getSites();
 
-        if (is_array($value)) {
-            foreach ($value as $id) {
-                if (!isset($sites[$id])) {
-                    $element->addError($this->handle, Craft::t('sites-field', 'Invalid site selected.'));
-                }
-            }
-        } else {
-            if (!isset($sites[$value])) {
-                $element->addError($this->handle, Craft::t('sites-field', 'Invalid site selected.'));
-            }
-        }
+		if (is_array($value)) {
+			foreach ($value as $id) {
+				if (!isset($sites[$id])) {
+					$element->addError($this->handle, Craft::t('sites-field', 'Invalid site selected.'));
+				}
+			}
+		} else {
+			if (!isset($sites[$value])) {
+				$element->addError($this->handle, Craft::t('sites-field', 'Invalid site selected.'));
+			}
+		}
 
 	}
 
 	/**
 	 * Retrieves all sites in an id, name pair, suitable for the underlying options display.
 	 */
-	private function getSites() {
+	private function getSites()
+	{
 		$sites = [];
 		foreach (Craft::$app->getSites()->getAllSites() as $site) {
 			$sites[$site->id] = Craft::t('site', $site->name);
 		}
 		return $sites;
-    }
-    
-    /**
+	}
+
+	/**
 	 * @inheritdoc
 	 */
-	public function normalizeValue ($value, ElementInterface $element = null)
+	public function normalizeValue($value, ElementInterface $element = null)
 	{
-		return (is_array($value)) ? $value : (string) json_decode($value);
+		return (is_array($value)) ? $value : (string)json_decode($value);
 	}
 
 }

--- a/src/templates/_settings.html
+++ b/src/templates/_settings.html
@@ -6,8 +6,8 @@
 	id : 'whitelistedSites',
 	name : 'whitelistedSites',
 	values: field.whitelistedSites,
-  showAllOption: true,
-  errors: field.getErrors('whitelistedSites'),
+	showAllOption: true,
+	errors: field.getErrors('whitelistedSites'),
 	options : sites
 }) }}
 


### PR DESCRIPTION
The default settings in my editor were different than the existing code style being used on this project when I committed my prior PRs. This commit fixes whitespace to match the existing code and adds an editorconfig file so that supporting editors will automatically use a consistent formatting. I tried to match this as best as I could determine to be the existing format.