### PR TITLE
fix array to string exception when normalizing a json string that con…

### DIFF
--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -207,7 +207,10 @@ class SitesField extends Field implements PreviewableFieldInterface
 	 */
 	public function normalizeValue ($value, ElementInterface $element = null)
 	{
-		return (is_array($value)) ? $value : (string) json_decode($value);
+        if($this->allowMultiple && is_string($value)) {
+            $value = json_decode($value);
+        }
+        return $value;
 	}
 
 }


### PR DESCRIPTION
…tains an array

Previously I didnt fully understand all the places this was being used. I changed the logic to decide to json decode based on whether we are expecting there to be an array in the string vs just a number (if allow multiple is false, there should only be a single number).

If you choose to switch to using `$site->uid` instead of `$site->id` (see #8) this will no longer be needed and we can simply `return json_decode($value);`.
