### PR TITLE
 Change key from ID to UID

### DIFF
--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -90,7 +90,7 @@ class SitesField extends Field implements PreviewableFieldInterface
 	 * @inheritdoc
 	 * @see craft\base\Field
 	 */
-	public function defineRules(): array
+	public function rules(): array
 	{
 		$rules = parent::rules();
 		$rules[] = [['whitelistedSites'], 'validateSitesWhitelist', 'skipOnEmpty' => false];

--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -198,7 +198,7 @@ class SitesField extends Field implements PreviewableFieldInterface
 	{
 		$sites = [];
 		foreach (Craft::$app->getSites()->getAllSites() as $site) {
-			$sites[$site->id] = Craft::t('site', $site->name);
+			$sites[$site->uid] = Craft::t('site', $site->name);
 		}
 		return $sites;
 	}

--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -90,9 +90,9 @@ class SitesField extends Field implements PreviewableFieldInterface
 	 * @inheritdoc
 	 * @see craft\base\Field
 	 */
-	public function rules(): array
+	public function defineRules(): array
 	{
-		$rules = parent::rules();
+		$rules = parent::defineRules();
 		$rules[] = [['whitelistedSites'], 'validateSitesWhitelist', 'skipOnEmpty' => false];
 
 		return $rules;

--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -68,7 +68,7 @@ class SitesField extends Field implements PreviewableFieldInterface
 	 */
 	public function getContentColumnType(): string
 	{
-		return Schema::TYPE_STRING;
+		return Schema::TYPE_TEXT;
 	}
 
 	/**


### PR DESCRIPTION
The site id is DB data. It would be preferable to not reference identifiers managed by the DB in the project.yaml config file because this creates the possibility of referencing data that does not exist or that is different (a different DB may associate a different site id with the same logical site depending on creation order). This is not really a problem when there is only one DB, but in situations where there is separate test site DBs or local dev DBs it is best to keep a distinction between config that is shared in the code repos and data in the DB.

The project.yaml file references sites by the site uid, so it would be better to store that as part of the field config instead.

This will be a breaking change for existing users of the plugin, they have to reconfigure each field type where they use this plugin and migrate each user site config.

Related pr: https://github.com/eastslopestudio/craft3-sites-field/issues/8

The defineRules in reality should be called rules, if not the parent will try to load this method and try again to load rules, then defineRules ...