### PR TITLE
feat: add support for sitegroups

### DIFF
--- a/src/templates/_input.html
+++ b/src/templates/_input.html
@@ -1,22 +1,93 @@
 {% import '_includes/forms' as forms %}
 
 {% if field.allowMultiple %}
-	{{ forms.checkboxGroup({
-		id : field.handle,
-		name : field.handle,
-		values: value,
-		placeholder: 'Choose Sites...' | t('sites-field'),
-		options: sites
-	}) }}
+<fieldset class="checkbox-group">
+	<input type="hidden" name="field.handle" value="">
+	<div>
+		{% set siteIds = siteIds ?? craft.app.sites.getEditableSiteIds() %}
+		{% if siteIds|length %}
+		{% if selectedSiteId is not defined %}
+		{% if craft.app.sites.currentSite.id in siteIds %}
+		{% set selectedSiteId = craft.app.sites.currentSite.id %}
+		{% else %}
+		{% set selectedSiteId = siteIds|first %}
+		{% endif %}
+		{% endif %}
+		{% set groups = craft.app.sites.getAllGroups() %}
+
+		{% for group in groups %}
+		{% set groupSiteIds = group.getSiteIds()|intersect(siteIds) %}
+		{% if groupSiteIds %}
+		{% if groups|length > 1 %}<h6>{{ group.name|t('site') }}</h6>{% endif %}
+		<ul class="padded">
+			{% for siteId in groupSiteIds %}
+			{% set site = craft.app.sites.getSiteById(siteId) %}
+			{% set url = urlFormat is defined ? url(urlFormat|replace({
+			'{id}': siteId,
+			'{handle}': site.handle
+			})) %}
+			{% if site.uid in sites|keys%}
+			<li>
+				<input type="checkbox"
+					   class="checkbox"
+					   id="{{ site.id }}"
+					   name="{{ field.handle }}[]"
+					   value="{{ site.uid }}"
+					   {% if site.uid in value %}checked{% endif %}>
+				<label for="{{ site.id }}">{{ site.name|t('site') }}</label>
+			</li>
+			{% endif %}
+			{% endfor %}
+		</ul>
+		{% endif %}
+		{% endfor %}
+		{% endif %}
+	</div>
+</fieldset>
 {% else %}
-	{{ forms.select({
-		id : field.handle,
-		name : field.handle,
-		value: value,
-		placeholder: 'Choose a Site...' | t('sites-field'),
-		options: sites
-	}) }}
-	{% if value is iterable %}
-		<p class="warning">{{ "Multiple sites selected, but field only allows one site. Selecting a new value will clear the existing multiple sites selection." | t('sites-field') }}</p>
-	{% endif %}
+<div class="select">
+	<select id="{{ field.handle }}" name="{{ field.handle }}">
+		{% set siteIds = siteIds ?? craft.app.sites.getEditableSiteIds() %}
+		{% if siteIds|length %}
+		{% if selectedSiteId is not defined %}
+		{% if craft.app.sites.currentSite.id in siteIds %}
+		{% set selectedSiteId = craft.app.sites.currentSite.id %}
+		{% else %}
+		{% set selectedSiteId = siteIds|first %}
+		{% endif %}
+		{% endif %}
+		{% set groups = craft.app.sites.getAllGroups() %}
+
+		{% for group in groups %}
+		{% set groupSiteIds = group.getSiteIds()|intersect(siteIds) %}
+		{% if groupSiteIds %}
+		{% if groups|length > 1 %} <optgroup label="{{ group.name|t('site') }}">{% endif %}
+
+		{% for siteId in groupSiteIds %}
+		{% set site = craft.app.sites.getSiteById(siteId) %}
+		{% set url = urlFormat is defined ? url(urlFormat|replace({
+		'{id}': siteId,
+		'{handle}': site.handle
+		})) %}
+		{% if site.uid in sites|keys%}
+
+		<option id="{{ site.id }}"
+				name="{{ field.handle }}[]"
+				value="{{ site.uid }}"
+				{% if site.uid in value %}selected{% endif %}>{{ site.name|t('site') }}</option>
+
+		{% endif %}
+		{% endfor %}
+
+		{% if groups|length > 1 %} </optgroup>{% endif %}
+
+		{% endif %}
+		{% endfor %}
+		{% endif %}
+	</select>
+</div>
+{% if value is iterable %}
+<p class="warning">{{ "Multiple sites selected, but field only allows one site. Selecting a new
+	value will clear the existing multiple sites selection." | t('sites-field') }}</p>
+{% endif %}
 {% endif %}


### PR DESCRIPTION
If you have a few sites with the same name but belonging to a different sitegroup, makes it very difficult to know which is the correct

I've added support for sitegroups

<img width="263" alt="Captura de pantalla 2021-12-24 a las 7 34 18" src="https://user-images.githubusercontent.com/90317987/147325627-54ed657d-63b8-471b-9197-9791b8bd16a2.png">
<img width="309" alt="Captura de pantalla 2021-12-24 a las 7 33 03" src="https://user-images.githubusercontent.com/90317987/147325631-18f1b95c-4269-4a31-b424-919601c2ca55.png">
<img width="292" alt="Captura de pantalla 2021-12-24 a las 7 32 47" src="https://user-images.githubusercontent.com/90317987/147325635-3b06ea94-4a2a-4c3a-a0e6-59c64699e5da.png">

If everything is correct, could you create a tag and update packagist.

Thanks

